### PR TITLE
Using create classmethod for bot initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,26 @@ python -m api
 
 ### Run Bot
 [Bot README.md](src/bot/README.md) \
-1. Install the necessary python packages with
+1. Navigate into the `src/bot` directory with
 ```cmd
-pip install -r src/api/requirements.txt
+cd src/bot
 ```
-2. Add the necessary environment variables in your local `.env`
+2. Install the necessary python packages with
+```cmd
+pip install -r requirements.txt
+```
+3. Add the necessary environment variables in your local `.env`
 These can be found in `src/bot/.env.example` and are listed below as well:
 
 ```
 TOKEN=
 API_URL=
 ```
-3. Run the bot with
+4. Navigate back into the `src` directory with
+```cmd
+cd ..
+```
+5. Run the bot with
 ```cmd
 python -m bot
 ```

--- a/src/bot/__main__.py
+++ b/src/bot/__main__.py
@@ -1,18 +1,14 @@
-import discord
-from discord.ext import commands
-
-from glob import glob
-from pathlib import Path
-from constants import environment
+from bot.constants import environment
 from discord_slash import SlashCommand
 
-from arena_bot import ArenaBot
+from bot.arena_bot import ArenaBot
 
-bot = commands.Bot(command_prefix="!")
-slash = SlashCommand(bot, sync_commands=True, override_type=True)
+def main() -> None:
+    bot = ArenaBot.create()
+    SlashCommand(bot, sync_commands=True, override_type=True)
 
-for file in map(Path, glob("bot/cogs/*.py")):
-    bot.load_extension(f"cogs.{file.stem}")
+    bot.load_extensions()
+    bot.run(environment.TOKEN)
 
-
-bot.run(environment.TOKEN)
+if __name__ == "__main__":
+    main()

--- a/src/bot/arena_bot.py
+++ b/src/bot/arena_bot.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
+from glob import glob
+from pathlib import Path
+
 import aiohttp
+import discord
 from discord.ext.commands import Bot
 
 
 class ArenaBot(Bot):
     def __init__(self, command_prefix, *args, **kwargs):
         super().__init__(command_prefix, *args, **kwargs)
-
         self.session = aiohttp.ClientSession()
 
     async def on_ready(self):
@@ -13,3 +18,16 @@ class ArenaBot(Bot):
 
     async def on_disconnect(self):
         await self.session.close()
+
+    def load_extensions(self) -> None:
+        for file in map(Path, glob("bot/cogs/*.py")):
+            self.load_extension(f"bot.cogs.{file.stem}")
+
+    @classmethod
+    def create(cls) -> ArenaBot:
+        bot_intents = discord.Intents.default()
+        bot = cls(
+            command_prefix='!',
+            intents=bot_intents
+        )
+        return bot

--- a/src/bot/cogs/player.py
+++ b/src/bot/cogs/player.py
@@ -3,8 +3,8 @@ from discord.ext.commands import Cog
 from discord_slash.cog_ext import cog_slash
 from discord_slash import SlashContext
 
-from constants import environment
-from arena_bot import ArenaBot
+from bot.constants import environment
+from bot.arena_bot import ArenaBot
 
 
 class Player(Cog):
@@ -13,7 +13,7 @@ class Player(Cog):
         self._api_url = f"http://{environment.API_URL}"
 
     @cog_slash(name="join", description="Register Your Account.")
-    async def join(self, ctx: SlashContext):
+    async def join(self, ctx: SlashContext) -> None:
         params = {
             "id": ctx.author.id,
             "display_name": ctx.author.display_name
@@ -28,5 +28,9 @@ class Player(Cog):
                 await ctx.send("> You already exist")
 
 
-def setup(bot: ArenaBot):
+def setup(bot: ArenaBot) -> None:
     bot.add_cog(Player(bot))
+
+
+def teardown(bot: ArenaBot) -> None:
+    bot.remove_cog('Player')

--- a/src/bot/constants/__init__.py
+++ b/src/bot/constants/__init__.py
@@ -1,0 +1,1 @@
+from .environment import setting

--- a/src/bot/constants/environment.py
+++ b/src/bot/constants/environment.py
@@ -1,4 +1,4 @@
-from utils import setting
+from bot.utils import setting
 
 TOKEN = setting("TOKEN")
 API_URL = setting("API_URL")

--- a/src/bot/requirements.txt
+++ b/src/bot/requirements.txt
@@ -3,11 +3,10 @@ async-timeout==3.0.1
 attrs==20.3.0
 chardet==4.0.0
 discord==1.0.1
+discord-py-slash-command==1.1.2
 discord.py==1.7.1
 idna==3.1
 multidict==5.1.0
 python-dotenv==0.17.0
 typing-extensions==3.7.4.3
 yarl==1.6.3
-discord-py-slash-command==1.1.2
-


### PR DESCRIPTION
Using a python classmethod `create` within the `ArenaBot` class to create the bot and encapsulate all bot initialization logic. Also changed `README.md` to reflect correct bot setup instructions according to this pull request.